### PR TITLE
fixed accessing salesforce version

### DIFF
--- a/salesforce_bulk_api.py
+++ b/salesforce_bulk_api.py
@@ -55,8 +55,8 @@ class SalesforceBulkJob:
         self.session_id = salesforce.session_id
         self.async_url = (salesforce.base_url
                                     .replace('/data/', '/async/')
-                                    .replace('v' + salesforce.version,
-                                             salesforce.version))
+                                    .replace('v' + salesforce.sf_version,
+                                             salesforce.sf_version))
 
         assert operation in self.SUPPORTED_OPERATIONS, '{} is not a valid bulk operation.'.format(operation)
         self.operation = operation

--- a/test_bulk_salesforce.py
+++ b/test_bulk_salesforce.py
@@ -176,7 +176,7 @@ def salesforce_session():
     """Prepares a mock Salesforce session for the test suite"""
     with mock.patch('salesforce_bulk_api.salesforce_session') as salesforce_session:
         salesforce_session.return_value.session_id = 'the-session-id'
-        salesforce_session.return_value.version = '34.0'
+        salesforce_session.return_value.sf_version = '34.0'
         salesforce_session.return_value.base_url = 'https://salesforce/services/data/v34.0/'
 
         salesforce_session.return_value.describe.return_value = {


### PR DESCRIPTION
When I tried to use the library (in Python 3), I've got the following error:

```
  File "/usr/local/lib/python3.5/site-packages/salesforce_bulk_api.py", line 58, in __init__
    .replace('v' + salesforce.version,
TypeError: Can't convert 'SFType' object to str implicitly
```

Looks like string representation of the version is written into `sf_version` of Salesforce object.

Tried this fix locally and it works.