### PR TITLE
Added possibility provide custom SalesForce object

### DIFF
--- a/salesforce_bulk_api.py
+++ b/salesforce_bulk_api.py
@@ -46,12 +46,13 @@ class SalesforceBulkJob:
     PUBLISHING_BATCH_SIZE = 9999
     SUPPORTED_OPERATIONS = {'insert', 'update', 'delete', 'upsert'}
 
-    def __init__(self, operation, object_name, external_id_field=None):
+    def __init__(self, operation, object_name, external_id_field=None, salesforce=None):
         """Creates a new API interface to Salesforce's bulk API, from which any
         number of jobs may be created.  The operation should be one of ('insert',
         'update', 'upsert', or 'delete'), and the object_name should be the
         proper-case name of a Salesforce object (like Lead or Contact)."""
-        salesforce = salesforce_session()
+        if not salesforce:
+            salesforce = salesforce_session()
         self.session_id = salesforce.session_id
         self.async_url = (salesforce.base_url
                                     .replace('/data/', '/async/')


### PR DESCRIPTION
Custom object required when you have diff configuration variables, or different authorisation logic, by default simple_salesforce uses SOAP, but possible variants with OAuth, etc...